### PR TITLE
fix(otel-collector-config): Jaeger is not a valid exporter for t…

### DIFF
--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -8,7 +8,7 @@ receivers:
 exporters:
   logging:
     verbosity: Detailed
-  jaeger:
+  otlp:
     endpoint: jaeger-all-in-one:14250
     tls:
       insecure: true
@@ -21,5 +21,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, jaeger]
+      exporters: [logging, otlp]
       processors: [batch]


### PR DESCRIPTION
Jaeger is not a valid exporter for the latest Otelm collector. Currently the following exports are allowed:

      - debug
      - logging
      - otlp
      - azuredataexplorer
      - googlecloud
      - influxdb
      - prometheusremotewrite
      - datadog
      - instana
      - mezmo
      - sapm
      - signalfx
      - otlphttp
      - azuremonitor
      - cassandra
      - dataset
      - opencensus
      - awscloudwatchlogs
      - googlemanagedprometheus
      - logicmonitor
      - loki
      - tencentcloud_logservice
      - file
      - alibabacloud_logservice
      - awsemf
      - awskinesis
      - awsxray
      - carbon
      - clickhouse
      - dynatrace
      - loadbalancing
      - sumologic
      - f5cloud
      - kafka
      - prometheus
      - sentry
      - skywalking
      - zipkin
      - awss3
      - elasticsearch
      - logzio
      - pulsar
      - splunk_hec
      - coralogix
      - googlecloudpubsub
      - tan
      - zuobservability

To fix, Change to otlp:

```yaml
otlp:
    endpoint: jaeger:4317
    tls:
      insecure: true
```